### PR TITLE
move _fadvise.so from python tld to module dir

### DIFF
--- a/fadvise/__init__.py
+++ b/fadvise/__init__.py
@@ -43,7 +43,7 @@ merely constitutes an expectation on behalf of the application.
 
 import os
 
-from _fadvise import posix_fadvise, POSIX_FADV_NORMAL, POSIX_FADV_RANDOM, \
+from fadvise._fadvise import posix_fadvise, POSIX_FADV_NORMAL, POSIX_FADV_RANDOM, \
  POSIX_FADV_SEQUENTIAL, POSIX_FADV_WILLNEED, POSIX_FADV_DONTNEED, \
  POSIX_FADV_NOREUSE
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
 
     packages=find_packages(),
     ext_modules=[
-        Extension('_fadvise', sources=['_fadvise.c']),
+        Extension('fadvise._fadvise', sources=['_fadvise.c']),
     ],
 )


### PR DESCRIPTION
Move the sofile from the python top level directory to the module directory to keep the top level dir clean.
