### PR TITLE
python 3 module init

### DIFF
--- a/_fadvise.c
+++ b/_fadvise.c
@@ -55,21 +55,31 @@ method_posix_fadvise(PyObject *self, PyObject *args)
 	Py_RETURN_NONE;
 }
 
-static PyMethodDef PosixFadviseMethods[] = {
+static PyMethodDef fadvise_module_methods[] = {
 	{"posix_fadvise", method_posix_fadvise, METH_VARARGS,
 		"posix_fadvise(fd, offset, len, advice)"},
 	{NULL, NULL, 0, NULL}
 };
 
-PyMODINIT_FUNC
-init_fadvise(void)
+struct PyModuleDef Fadvise =
 {
-	PyObject *m = Py_InitModule("_fadvise", PosixFadviseMethods);
+    PyModuleDef_HEAD_INIT,
+    "fadvise", /* name of module */
+    "usage: fadvise._fadvise(stream, offset, len, constant)\n", /* module documentation, may be NULL */
+    -1,   /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+    fadvise_module_methods
+};
 
+PyMODINIT_FUNC
+PyInit__fadvise(void)
+{
+        PyMODINIT_FUNC m = PyModule_Create(&Fadvise);
 	PyModule_AddIntConstant(m, "POSIX_FADV_NORMAL", POSIX_FADV_NORMAL);
 	PyModule_AddIntConstant(m, "POSIX_FADV_RANDOM", POSIX_FADV_RANDOM);
 	PyModule_AddIntConstant(m, "POSIX_FADV_SEQUENTIAL", POSIX_FADV_SEQUENTIAL);
 	PyModule_AddIntConstant(m, "POSIX_FADV_WILLNEED", POSIX_FADV_WILLNEED);
 	PyModule_AddIntConstant(m, "POSIX_FADV_DONTNEED", POSIX_FADV_DONTNEED);
 	PyModule_AddIntConstant(m, "POSIX_FADV_NOREUSE", POSIX_FADV_NOREUSE);
+        return m;
 }
+


### PR DESCRIPTION
Updated the initialization code to work in current python versions.
Seems to be working for me, at least, in python 3.9.18. 